### PR TITLE
8 Decrease deployment limits

### DIFF
--- a/api/main.tf
+++ b/api/main.tf
@@ -99,15 +99,17 @@ resource aws_ecs_task_definition sp_api {
 }
 
 resource aws_ecs_service sp_api {
-  name                              = "sp-api"
-  desired_count                     = 2
-  health_check_grace_period_seconds = 300
-  task_definition                   = aws_ecs_task_definition.sp_api.arn
-  cluster                           = var.ecs_cluster_arn
+  name                               = "sp-api"
+  health_check_grace_period_seconds  = 300
+  task_definition                    = aws_ecs_task_definition.sp_api.arn
+  cluster                            = var.ecs_cluster_arn
+  desired_count                      = 2
+  deployment_minimum_healthy_percent = 50
+  deployment_maximum_percent         = 100
 
   capacity_provider_strategy {
-    base   = 0
-    weight = 1
+    base              = 0
+    weight            = 1
     capacity_provider = var.ecs_capacity_provider_name
   }
 
@@ -117,14 +119,14 @@ resource aws_ecs_service sp_api {
   }
 
   network_configuration {
-    subnets = data.aws_subnets.sp_api.ids
+    subnets         = data.aws_subnets.sp_api.ids
     security_groups = data.aws_security_groups.sp_api.ids
   }
 
   load_balancer {
     container_name   = local.container_name
     target_group_arn = var.lb_target_group_arn
-    container_port = tonumber(data.aws_ssm_parameter.api_port.value)
+    container_port   = tonumber(data.aws_ssm_parameter.api_port.value)
   }
 
   tags = {

--- a/app/main.tf
+++ b/app/main.tf
@@ -17,14 +17,14 @@ data aws_ssm_parameter app_port {
 
 data aws_security_groups sp_app {
   filter {
-    name = "tag:Name"
+    name   = "tag:Name"
     values = ["sp-app"]
   }
 }
 
 data aws_subnets sp_app {
   filter {
-    name = "tag:Name"
+    name   = "tag:Name"
     values = ["sp-app"]
   }
 }
@@ -69,11 +69,14 @@ resource aws_ecs_task_definition sp_app {
 }
 
 resource aws_ecs_service sp_app {
-  name                              = "sp-app"
-  desired_count                     = 2
-  health_check_grace_period_seconds = 300
-  task_definition                   = aws_ecs_task_definition.sp_app.arn
-  cluster                           = var.ecs_cluster_arn
+  name                               = "sp-app"
+  health_check_grace_period_seconds  = 300
+  task_definition                    = aws_ecs_task_definition.sp_app.arn
+  cluster                            = var.ecs_cluster_arn
+  desired_count                      = 2
+  deployment_minimum_healthy_percent = 50
+  deployment_maximum_percent         = 100
+
 
   capacity_provider_strategy {
     base              = 0

--- a/auth/main.tf
+++ b/auth/main.tf
@@ -144,7 +144,7 @@ resource aws_ecs_task_definition sp_auth {
             value = "ecto://${data.aws_ssm_parameter.db_username.value}:${data.aws_ssm_parameter.db_password.value}@${var.db_address}/${data.aws_ssm_parameter.db_name.value}"
           },
           {
-            name = "VERIFICATION_URL",
+            name  = "VERIFICATION_URL",
             value = "https://www.spaced-reps.com"
           }
         ]
@@ -158,11 +158,13 @@ resource aws_ecs_task_definition sp_auth {
 }
 
 resource aws_ecs_service sp_auth {
-  name                              = "sp-auth"
-  desired_count                     = 2
-  health_check_grace_period_seconds = 300
-  task_definition                   = aws_ecs_task_definition.sp_auth.arn
-  cluster                           = var.ecs_cluster_arn
+  name                               = "sp-auth"
+  health_check_grace_period_seconds  = 300
+  task_definition                    = aws_ecs_task_definition.sp_auth.arn
+  cluster                            = var.ecs_cluster_arn
+  desired_count                      = 2
+  deployment_minimum_healthy_percent = 50
+  deployment_maximum_percent         = 100
 
   capacity_provider_strategy {
     base              = 0
@@ -183,7 +185,7 @@ resource aws_ecs_service sp_auth {
   load_balancer {
     container_name   = local.container_name
     target_group_arn = var.lb_target_group_arn
-    container_port = tonumber(data.aws_ssm_parameter.auth_port.value)
+    container_port   = tonumber(data.aws_ssm_parameter.auth_port.value)
   }
 
   tags = {


### PR DESCRIPTION
The service only has two instances provisioned with one task running in each.Withe a maximum of 200% and minimum of 100%, on redeployment of a service we are stuck in a state where not enough resources are available to complete the deployment.

With this changes, 1 task/instance is drained from incumbent deployment while the another task is started in the new deployment, and the same is done for the second task after the first has been done.

Closes #8