### PR TITLE
17 Set network mode to bridge

### DIFF
--- a/api/main.tf
+++ b/api/main.tf
@@ -46,7 +46,7 @@ locals {
 
 resource "aws_ecs_task_definition" "sp_api" {
   family                   = "sp-api"
-  network_mode             = "awsvpc"
+  network_mode             = "bridge"
   requires_compatibilities = ["EC2"]
   execution_role_arn       = data.aws_iam_role.sp.arn
 
@@ -116,11 +116,6 @@ resource "aws_ecs_service" "sp_api" {
   deployment_circuit_breaker {
     enable   = true
     rollback = true
-  }
-
-  network_configuration {
-    subnets         = data.aws_subnets.sp_api.ids
-    security_groups = data.aws_security_groups.sp_api.ids
   }
 
   load_balancer {

--- a/load_balancer/main.tf
+++ b/load_balancer/main.tf
@@ -66,7 +66,7 @@ resource "aws_lb_target_group" "sp_auth" {
 
 resource "aws_lb_target_group" "sp_api" {
   protocol    = "HTTP"
-  target_type = "ip"
+  target_type = "instance"
 
   name   = "sp-api"
   vpc_id = data.aws_vpc.sp.id


### PR DESCRIPTION
Set the network mode bridge so that the instance container network interface is bridged to that of the host instance, and thus are able to connect to the internet.The assumption here is that the host instance itself is able to connect to the internet.

Closes #17 